### PR TITLE
Update version to 0.57.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,6 +70,7 @@ requirements:
     - deprecated >=1.2.14,<2.0.0
     - aiohttp >=3.11.11,<4.0.0
     - cuid >=0.4.0,<0.5.0
+    - httpx
 
 test:
   imports:
@@ -78,7 +79,6 @@ test:
     - pip check
   requires:
     - pip
-    - httpx
 
 about:
   home: https://www.traceloop.com/openllmetry

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,16 +21,16 @@ requirements:
     - hatchling
   run:
     - python
-    - opentelemetry-api >=1.28.0,<2.0.0
-    - opentelemetry-sdk >=1.28.0,<2.0.0
-    - opentelemetry-exporter-otlp-proto-http >=1.28.0,<2.0.0
-    - opentelemetry-exporter-otlp-proto-grpc >=1.28.0,<2.0.0
-    - opentelemetry-instrumentation-logging >=0.57b0
-    - opentelemetry-instrumentation-requests >=0.50b0
-    - opentelemetry-instrumentation-sqlalchemy >=0.50b0
-    - opentelemetry-instrumentation-urllib3 >=0.50b0
-    - opentelemetry-instrumentation-threading >=0.50b0
-    - opentelemetry-instrumentation-redis >=0.50b0
+    - opentelemetry-api >=1.38.0,<2.0.0
+    - opentelemetry-sdk >=1.38.0,<2.0.0
+    - opentelemetry-exporter-otlp-proto-http >=1.38.0,<2.0.0
+    - opentelemetry-exporter-otlp-proto-grpc >=1.38.0,<2.0.0
+    - opentelemetry-instrumentation-logging  >=0.59b0
+    - opentelemetry-instrumentation-requests >=0.59b0
+    - opentelemetry-instrumentation-sqlalchemy >=0.59b0
+    - opentelemetry-instrumentation-urllib3 >=0.59b0
+    - opentelemetry-instrumentation-threading >=0.59b0
+    - opentelemetry-instrumentation-redis >=0.59b0
     - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
     - opentelemetry-instrumentation-agno =={{ version }}
     - opentelemetry-instrumentation-voyageai =={{ version }}
@@ -68,7 +68,6 @@ requirements:
     - pydantic >=1
     - jinja2 >=3.1.5,<4.0.0
     - deprecated >=1.2.14,<2.0.0
-    - posthog >3.0.2,<4
     - aiohttp >=3.11.11,<4.0.0
     - cuid >=0.4.0,<0.5.0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "traceloop-sdk" %}
-{% set version = "0.47.2" %}
+{% set version = "0.57.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_')}}-{{ version }}.tar.gz
-  sha256: 92b950834966bd58aca3c0fdeeabd774290d5392b4802757c7e014a6bee6def0
+  sha256: 14435a168d02fbf162d6310b54dc793b695a4941b2a9897070c75e170deb2cd0
 
 build:
   number: 0
@@ -18,7 +18,7 @@ requirements:
   host:
     - pip
     - python
-    - poetry-core
+    - hatchling
   run:
     - python
     - opentelemetry-api >=1.28.0,<2.0.0
@@ -31,7 +31,9 @@ requirements:
     - opentelemetry-instrumentation-urllib3 >=0.50b0
     - opentelemetry-instrumentation-threading >=0.50b0
     - opentelemetry-instrumentation-redis >=0.50b0
-    - opentelemetry-semantic-conventions-ai >=0.4.13,<0.5.0
+    - opentelemetry-semantic-conventions-ai >=0.5.1,<0.6.0
+    - opentelemetry-instrumentation-agno =={{ version }}
+    - opentelemetry-instrumentation-voyageai =={{ version }}
     - opentelemetry-instrumentation-mistralai =={{ version }}
     - opentelemetry-instrumentation-openai =={{ version }}
     - opentelemetry-instrumentation-openai-agents =={{ version }}
@@ -77,6 +79,7 @@ test:
     - pip check
   requires:
     - pip
+    - httpx
 
 about:
   home: https://www.traceloop.com/openllmetry


### PR DESCRIPTION
traceloop-sdk 0.57.0

**Destination channel:**  defaults

### Links

- [PKG-12084](https://anaconda.atlassian.net/browse/PKG-12084) 
- [Upstream repository](https://github.com/traceloop/openllmetry/tree/v0.57.0)

### Explanation of changes:
- New version number


[PKG-12084]: https://anaconda.atlassian.net/browse/PKG-12084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ